### PR TITLE
 Python and Ruby FFI example and instruction to generate EMBOSS shared library

### DIFF
--- a/src/python-ffi/DNAtranslate.py
+++ b/src/python-ffi/DNAtranslate.py
@@ -1,12 +1,44 @@
+# Read a FASTA file a number of times (default once), translate
+# an print to STDOUT
+#
+# Usage:
+#
+#   python3 DNAtranslate.py dna.fa [n]
+#
+# Example
+#
+#   time python3 DNAtranslate.py ../../test/data/test-dna.fa
+#
+# Dependencies: python biopython
+
+verbose=False
+
+import sys
+from Bio.Seq import Seq
+from Bio import SeqIO
+from Bio.Alphabet import generic_dna
 from ctypes import *
 import os
 
+
+fn = sys.argv[1]
+times = 1
+if len(sys.argv) > 2:
+  times = int(sys.argv[2])
+
 emboss = cdll.LoadLibrary(os.path.join(os.path.dirname(os.path.abspath(__file__)),"emboss.so"))
-
 trnTable = emboss.ajTrnNewI(1)
-ajpseq   = emboss.ajSeqNewNameC(b"atgtcaatggtaagaaatgtatcaaatcagagcgaaaaattggaaattttgt", b"Test sequence")
-ajpseqt  = emboss.ajTrnSeqOrig(trnTable,ajpseq,1)
 
-seq = emboss.ajSeqGetSeqCopyC(ajpseqt)
-seq = str(c_char_p(seq).value,'utf-8')
-print(seq)
+if verbose:
+  sys.stderr.write('Biopython FFI translate ',fn, ':', times)
+for i in range(0, times):
+  if verbose:
+    sys.stderr.write( i+1 )
+  for seq_record in SeqIO.parse(fn, "fasta", generic_dna):
+    print(">",seq_record.id)
+    ajpseq   = emboss.ajSeqNewNameC(b"atgtcaatggtaagaaatgtatcaaatcagagcgaaaaattggaaattttgt", b"Test sequence")
+    ajpseqt  = emboss.ajTrnSeqOrig(trnTable,ajpseq,1)
+
+    seq = emboss.ajSeqGetSeqCopyC(ajpseqt)
+    seq = str(c_char_p(seq).value,'utf-8')
+    print(seq)

--- a/src/python-ffi/DNAtranslate.py
+++ b/src/python-ffi/DNAtranslate.py
@@ -1,0 +1,12 @@
+from ctypes import *
+import os
+
+emboss = cdll.LoadLibrary(os.path.join(os.path.dirname(os.path.abspath(__file__)),"emboss.so"))
+
+trnTable = emboss.ajTrnNewI(1)
+ajpseq   = emboss.ajSeqNewNameC(b"atgtcaatggtaagaaatgtatcaaatcagagcgaaaaattggaaattttgt", b"Test sequence")
+ajpseqt  = emboss.ajTrnSeqOrig(trnTable,ajpseq,1)
+
+seq = emboss.ajSeqGetSeqCopyC(ajpseqt)
+seq = str(c_char_p(seq).value,'utf-8')
+print(seq)

--- a/src/python-ffi/EGC.1
+++ b/src/python-ffi/EGC.1
@@ -1,0 +1,32 @@
+# Genetic Code Table
+#
+# Obtained from: http://www3.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi
+#
+#  Version 3.4
+#     Added CTG,TTG as allowed alternate start codons in Standard code.
+#        Prats et al. 1989, Hann et al. 1992
+#
+# Initiation Codon:
+#
+# AUG 
+# 
+# Alternative Initiation Codons
+#
+# In rare cases, translation in eukaryotes can be initiated from codons
+# other than AUG.  A well documented case (including direct protein
+# sequencing) is the GUG start of a ribosomal P protein of the fungus
+# Candida albicans (Abramczyk et al.).  Other examples can be found in the
+# following references: Peabody 1989; Prats et al.  1989; Hann et al. 
+# 1992; Sugihara et al.  1990. 
+#
+# GUG, CUG, UUG 
+
+Genetic Code [1]
+
+Standard
+ 
+AAs  =   FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG
+Starts = ---M---------------M---------------M----------------------------
+Base1  = TTTTTTTTTTTTTTTTCCCCCCCCCCCCCCCCAAAAAAAAAAAAAAAAGGGGGGGGGGGGGGGG
+Base2  = TTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGG
+Base3  = TCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAG

--- a/src/python-ffi/README.txt
+++ b/src/python-ffi/README.txt
@@ -1,0 +1,6 @@
+Configure and compile EMBOSS with `-fPIC` then create the shared library for FFI.
+From inside the EMBOSS distribution
+
+    gcc -shared -o emboss.so  ajax/zlib/*.o ajax/expat/*.o ajax/core/*.o ajax/pcre/*.o
+
+then copy there emboss.so where the FFI script is located.

--- a/src/ruby-ffi/DNAtranslate.rb
+++ b/src/ruby-ffi/DNAtranslate.rb
@@ -1,0 +1,63 @@
+#! /usr/bin/env ruby
+#
+# Sequence translation using the BioRuby (pure Ruby)
+#
+# Usage:
+#
+#   ./DNAtranslate.rb file.fa [n]
+#
+# Example
+#
+#   time ./DNAtranslate.rb ../../test/data/test-dna.fa
+#
+# Dependencies: ruby bioruby bigbio biolib
+#
+# To use JRuby use something like
+#
+#   time /opt/jre1.8.0_144/bin/java -jar ~/opt/jars/jruby-complete-9.1.13.0.jar DNAtranslate.rb ../../test/data/test-dna.fa
+#
+# To use Ruby 1.9 (which is twice as fast as 1.8) use something like
+#
+#   ruby1.9.1 -I ~/opt/ruby/bioruby/lib/ DNAtranslate.rb ../../test/data/test-dna.fa
+
+USAGE =<<EOM
+  ruby #{__FILE__} inputfile(s)
+EOM
+
+$: << File.dirname(__FILE__)+'/lib'
+
+require 'ffi'
+require 'bio'
+include Bio
+
+module Emboss
+  extend FFI::Library
+  ffi_lib "./emboss.so"
+  attach_function :ajTrnNewI, [:int], :pointer
+  attach_function :ajSeqNewNameC, [:pointer, :pointer], :pointer
+  attach_function :ajTrnSeqOrig, [:pointer, :pointer, :int], :pointer
+  attach_function :ajSeqGetSeqCopyC, [:pointer], :string
+end
+
+if ARGV.size < 1
+  print USAGE
+  exit 1
+end
+
+trnTable = Emboss.ajTrnNewI(1)
+
+
+ARGV.each do | fn |
+  raise "File #{fn} does not exist" if !File.exist?(fn)
+  Bio::FlatFile.auto(fn).each do | item |
+    seq = Sequence::NA.new(item.data)
+    ajpseq   = Emboss.ajSeqNewNameC("atgtcaatggtaagaaatgtatcaaatcagagcgaaaaattggaaattttgt", "Test sequence")
+    ajpseqt  = Emboss.ajTrnSeqOrig(trnTable,ajpseq,1)
+    aa = Emboss.ajSeqGetSeqCopyC(ajpseqt)
+    print "> ",item.definition,"\n"
+    print aa,"\n"
+  end
+end
+
+
+

--- a/src/ruby-ffi/EGC.1
+++ b/src/ruby-ffi/EGC.1
@@ -1,0 +1,32 @@
+# Genetic Code Table
+#
+# Obtained from: http://www3.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi
+#
+#  Version 3.4
+#     Added CTG,TTG as allowed alternate start codons in Standard code.
+#        Prats et al. 1989, Hann et al. 1992
+#
+# Initiation Codon:
+#
+# AUG 
+# 
+# Alternative Initiation Codons
+#
+# In rare cases, translation in eukaryotes can be initiated from codons
+# other than AUG.  A well documented case (including direct protein
+# sequencing) is the GUG start of a ribosomal P protein of the fungus
+# Candida albicans (Abramczyk et al.).  Other examples can be found in the
+# following references: Peabody 1989; Prats et al.  1989; Hann et al. 
+# 1992; Sugihara et al.  1990. 
+#
+# GUG, CUG, UUG 
+
+Genetic Code [1]
+
+Standard
+ 
+AAs  =   FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG
+Starts = ---M---------------M---------------M----------------------------
+Base1  = TTTTTTTTTTTTTTTTCCCCCCCCCCCCCCCCAAAAAAAAAAAAAAAAGGGGGGGGGGGGGGGG
+Base2  = TTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGG
+Base3  = TCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAG

--- a/src/ruby-ffi/README.txt
+++ b/src/ruby-ffi/README.txt
@@ -1,0 +1,6 @@
+Configure and compile EMBOSS with `-fPIC` then create the shared library for FFI.
+From inside the EMBOSS distribution
+
+    gcc -shared -o emboss.so  ajax/zlib/*.o ajax/expat/*.o ajax/core/*.o ajax/pcre/*.o
+
+then copy there emboss.so where the FFI script is located.


### PR DESCRIPTION
Includes:

1. Python and Ruby scrits to perform benchmarks with FFI, I am using the ffi standard library provided with Python so called ctypes and 'ffi' gem for Ruby
2. EMBOSS codon table
3. instruction on how to build the shared library for FFI that must be placed in the same directory of the script, shared library is not provided. 

